### PR TITLE
Enable total row Total row overriding

### DIFF
--- a/viewsight/hooks.py
+++ b/viewsight/hooks.py
@@ -27,6 +27,8 @@ app_license = "mit"
 # include js, css files in header of desk.html
 # app_include_css = "/assets/viewsight/css/viewsight.css"
 # app_include_js = "/assets/viewsight/js/viewsight.js"
+# below to overide report footer
+app_include_js = "/assets/viewsight/overrides/js/viewsight.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/viewsight/css/viewsight.css"

--- a/viewsight/overrides/js/viewsight.js
+++ b/viewsight/overrides/js/viewsight.js
@@ -1,0 +1,27 @@
+
+// frappe.provide("frappe.views");
+
+frappe.views.QueryReport = class QueryReport extends frappe.views.QueryReport {
+	show_footer_message() {
+		this.$report_footer && this.$report_footer.remove();
+		this.$report_footer = $(`<div class="report-footer text-muted"></div>`).appendTo(this.page.main);
+		if (this.tree_report) {
+			this.$tree_footer = $(`<div class="tree-footer col-md-6">
+				<button class="btn btn-xs btn-default" data-action="expand_all_rows">
+					${__('Expand All')}</button>
+				<button class="btn btn-xs btn-default" data-action="collapse_all_rows">
+					${__('Collapse All')}</button>
+			</div>`);
+			$(this.$report_footer).append(this.$tree_footer);
+			this.$tree_footer.find('[data-action=collapse_all_rows]').show();
+			this.$tree_footer.find('[data-action=expand_all_rows]').hide();
+		}
+
+		// const message = __('For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10).');
+		// const execution_time_msg = __('Execution Time: {0} sec', [this.execution_time || 0.1]);
+
+		// this.$report_footer.append(`<div class="col-md-12">
+		// 	<span">${message}</span><span class="pull-right">${execution_time_msg}</span>
+		// </div>`);
+	}
+}

--- a/viewsight/viewsight/report/stock_flow/stock_flow.json
+++ b/viewsight/viewsight/report/stock_flow/stock_flow.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 0,
+ "add_total_row": 1,
  "add_translate_data": 0,
  "columns": [],
  "creation": "2025-06-25 17:37:31.228773",
@@ -11,7 +11,7 @@
  "is_standard": "Yes",
  "letter_head": "",
  "letterhead": null,
- "modified": "2025-06-25 17:38:31.610124",
+ "modified": "2025-06-29 11:24:57.411544",
  "modified_by": "Administrator",
  "module": "Viewsight",
  "name": "Stock Flow",


### PR DESCRIPTION
In Stock flow report add total row was enable this is a default by the framework.
Overriding of Total row working and display by add a line on hooks-py file in my custom app and also creating a corresponding js file to that effect


![Screenshot 2025-06-29 at 11 35 16](https://github.com/user-attachments/assets/21ebc0d9-5ad9-468e-9427-3e1c922aa2e9)
